### PR TITLE
Add revision support to get cli command

### DIFF
--- a/cmd/doozer/get.go
+++ b/cmd/doozer/get.go
@@ -2,22 +2,24 @@ package main
 
 import (
 	"os"
+	"fmt"
 )
 
 
 func init() {
 	cmds["get"] = cmd{get, "<path>", "read a file"}
-	cmdHelp["get"] = "Prints the body of the file at <path>.\n"
+	cmdHelp["get"] = "Prints the body and revision of the file at <path>.\n"
 }
 
 
 func get(path string) {
 	c := dial()
 
-	body, _, err := c.Get(path, nil)
+	body, actualRev, err := c.Get(path, nil)
 	if err != nil {
 		bail(err)
 	}
 
+	fmt.Println("Revision:", actualRev)
 	os.Stdout.Write(body)
 }

--- a/cmd/doozer/get.go
+++ b/cmd/doozer/get.go
@@ -7,15 +7,27 @@ import (
 
 
 func init() {
-	cmds["get"] = cmd{get, "<path>", "read a file"}
+	cmds["get"] = cmd{get, "<path> <rev|nil>", "read a file"}
 	cmdHelp["get"] = "Prints the body and revision of the file at <path>.\n"
 }
 
 
-func get(path string) {
+func get(path string, rev string) {
 	c := dial()
 
-	body, actualRev, err := c.Get(path, nil)
+	var (
+		body      []byte
+		actualRev int64
+		err       os.Error
+	)
+
+	if rev == "nil" {
+		body, actualRev, err = c.Get(path, nil)
+	} else {
+		requestedRev := mustAtoi64(rev)
+		body, actualRev, err = c.Get(path, &requestedRev)
+	}
+
 	if err != nil {
 		bail(err)
 	}


### PR DESCRIPTION
I was playing around with the doozer client as a way of getting a feel for solving some problems with Doozer, and was surprised that get did not return the revision. I added this feature to the client. Since that was so easy, I also made another commit to allow passing a revision to get. You might not want the second commit in it's current form though - I wasn't sure how to make the revision argument optional. Cheers!
