### PR TITLE
fix pretty.go import path

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -4,7 +4,7 @@ import (
 	"code.google.com/p/goprotobuf/proto"
 	"encoding/binary"
 	"errors"
-	"github.com/kr/pretty.go"
+	"github.com/kr/pretty"
 
 	"io"
 	"log"


### PR DESCRIPTION
the repo has been moved. and goinstall fails:

```
$ GOPATH=$HOME/go go/bin/goinstall github.com/ha/doozer                                                   
go/bin/goinstall: github.com/kr/pretty.go: package has no files
```
