### PR TITLE
pretty.go package is renamed to pretty

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -4,7 +4,7 @@ import (
 	"code.google.com/p/goprotobuf/proto"
 	"encoding/binary"
 	"errors"
-	"github.com/kr/pretty.go"
+	"github.com/kr/pretty"
 
 	"io"
 	"log"


### PR DESCRIPTION
https://github.com/kr/pretty.go says:

"Renamed from pretty.go to pretty.

New URL: https://github.com/kr/pretty"
