### PR TITLE
switch to semver (fix go get)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 _obj
 _test*
 cmd/doozer/doozer
-cmd/doozer/vers.go

--- a/cmd/doozer/vers.go
+++ b/cmd/doozer/vers.go
@@ -1,0 +1,3 @@
+package main
+
+const version = `0.9.0`


### PR DESCRIPTION
the scripted version generation is problematic for go get and makes it difficult to maintain a changelog so I propose we switch to semver... cc @ha
