### PR TITLE
Fix go get instructions in the readme for the cli client.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To install the Go client:
 
 To install the CLI client:
 
-    $ go get github.com/ha/doozer/cmd
+    $ go get github.com/ha/doozer/cmd/doozer
 
 To use:
 


### PR DESCRIPTION
I was going to move `cmd/doozer/` to just be `doozer/`, but then I figured maybe it was done with `cmd/` in the path to be less confusing (`github.com/ha/doozer` and `github.com/ha/doozer/doozer` is strange). So I just updated the readme to be correct.
