### PR TITLE
Fix error help message.

### DIFF
--- a/cmd/doozer/help.go
+++ b/cmd/doozer/help.go
@@ -8,6 +8,6 @@ func init() {
 
 func help(command string) {
 	c := cmds[command]
-	fmt.Printf("Use: %s [options] %s [options] %s\n\n", self, command, c.a)
+	fmt.Printf("Use: %s [options] %s [options] %s\n\n", selfName, command, c.a)
 	fmt.Print(cmdHelp[command])
 }


### PR DESCRIPTION
Before: 

```
$ ./doozer set
set: wrong number of arguments
Use: %!s(func()=0x402f19) [options] set [options] <path> <rev>
...
```

After:

```
$ ./doozer set
set: wrong number of arguments
Use: ./doozer [options] set [options] <path> <rev>
...
```
