### PR TITLE
Remove references to command-specific options.

### DIFF
--- a/cmd/doozer/doozer.go
+++ b/cmd/doozer/doozer.go
@@ -32,9 +32,9 @@ var (
 
 const (
 	usage1 = `
-Each command takes zero or more options and zero or more arguments.
-In addition, there are some global options that can be used with any command.
-The exit status is 0 on success, 1 for a rev mismatch, and 2 otherwise.
+Each command takes zero or more arguments. In addition, there are some global
+options that can be used with any command. The exit status is 0 on success,
+1 for a rev mismatch, and 2 otherwise.
 
 Global Options:
 `
@@ -49,7 +49,7 @@ Commands:
 )
 
 func usage() {
-	fmt.Fprintf(os.Stderr, "Use: %s [options] <command> [options] [args]\n", selfName)
+	fmt.Fprintf(os.Stderr, "Use: %s [options] <command> [args]\n", selfName)
 	fmt.Fprint(os.Stderr, usage1)
 	flag.PrintDefaults()
 	fmt.Fprintln(os.Stderr)

--- a/cmd/doozer/help.go
+++ b/cmd/doozer/help.go
@@ -8,6 +8,6 @@ func init() {
 
 func help(command string) {
 	c := cmds[command]
-	fmt.Printf("Use: %s [options] %s [options] %s\n\n", self, command, c.a)
+	fmt.Printf("Use: %s [options] %s %s\n\n", self, command, c.a)
 	fmt.Print(cmdHelp[command])
 }


### PR DESCRIPTION
As far as I can tell, there are no commands that have options specific to that command (as opposed to global options). Also, we're using the stdlib flag package in such a way that we can't distinguish anyway. So for now, let's get rid of references to command-specific options.

```
doozer [OPTIONS] CMD [OPTIONS] ARGS
```

becomes

```
doozer [OPTIONS] CMD ARGS
```
