### PR TITLE
New cli command -- getr: return a body and rev

### DIFF
--- a/cmd/doozer/getr.go
+++ b/cmd/doozer/getr.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func init() {
+	cmds["getr"] = cmd{getr, "<path>", "read a file and its rev"}
+	cmdHelp["getr"] = `Prints the body and rev of the file at <path>.
+
+The format is:
+
+  <path> <rev> <len> LF <body> LF
+
+where LF is an ASCII line feed character.
+
+`
+}
+
+func getr(path string) {
+	c := dial()
+
+	body, rev, err := c.Get(path, nil)
+	if err != nil {
+		bail(err)
+	}
+
+	fmt.Println(path, rev, len(body))
+	os.Stdout.Write(body)
+	fmt.Println()
+}


### PR DESCRIPTION
Introduces the `getr` command to print the body, length, and rev for a path to avoid changing the existing get command.

The format is similar to `watch`/`wait`.

Example:

```
$ doozer getr /message
/message 3404 5
asdf

```
