### PR TITLE
Update rev doc to indicate that it takes no arguments.

### DIFF
--- a/cmd/doozer/rev.go
+++ b/cmd/doozer/rev.go
@@ -5,8 +5,8 @@ import (
 )
 
 func init() {
-	cmds["rev"] = cmd{rev, "<path>", "read a file"}
-	cmdHelp["rev"] = "Prints the current revision.\n"
+	cmds["rev"] = cmd{rev, "", "show current revision"}
+	cmdHelp["rev"] = "Prints the current revision of the store.\n"
 }
 
 func rev() {


### PR DESCRIPTION
This is consistent with what the `Rev()` API call actually does (and how the command currently behaves).
